### PR TITLE
chore: remove magithub config

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -45,9 +45,3 @@
   diff = diff-highlight | less
 [fetch]
   prune = true
-[magithub]
-  online = false
-[magithub "status"]
-  includeStatusHeader = false
-  includePullRequestsSection = false
-  includeIssuesSection = false


### PR DESCRIPTION
### **User description**
resolves #


___

### **PR Type**
Enhancement


___

### **Description**
- `magithub` セクションを`.gitconfig`から削除しました。

- `magithub`のオンライン設定を削除しました。

- `magithub "status"`セクションを削除しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitconfig</strong><dd><code>Remove magithub configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.gitconfig

- `[magithub]` セクションを削除しました。
- `[magithub "status"]` セクションを削除しました。


</details>


  </td>
  <td><a href="https://github.com/surume/dotfiles/pull/42/files#diff-3cbe50069f7ffe4d55b4d1fe7a72fb79e9c9545af55d8326a728b98f00481bf2">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information